### PR TITLE
Fix for Invalid Session on cluster startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "asciiart-logo": "^0.2.6",
     "colors": "^1.1.2",
-    "eris": "^0.10.0",
+    "eris": "^0.10.1",
     "fancy-log": "^1.3.0"
   },
   "devDependencies": {

--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -244,7 +244,7 @@ class ClusterManager extends EventEmitter {
                         this.queue.queue.splice(0, 1);
 
                         if (this.queue.queue.length > 0) {
-                            this.queue.executeQueue();
+                            setTimeout(this.queue.executeQueue, 5000);
                         }
                         break;
                     case "cluster":


### PR DESCRIPTION
Just a simple setTimeout between starting up clusters. Should fix the Invalid Session when connecting the first shard of every cluster.