### PR TITLE
Fix fetchInfo IPC error

### DIFF
--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -481,9 +481,9 @@ class ClusterManager extends EventEmitter {
     }
 
     fetchInfo(start, type, value) {
-        let worker = master.workers[this.clusters.get(start).workerID];
-        if (worker) {
-            worker.send({ name: type, value: value });
+        let cluster = this.clusters.get(start);
+        if (cluster) {
+            master.workers[cluster.workerID].send({ name: type, value: value });
             this.fetchInfo(start + 1, type, value);
         }
     }


### PR DESCRIPTION
Fixes the same error that happened with broadcast method.

```
TypeError: Cannot read property 'workerID' of undefined
    at ClusterManager.fetchInfo (eris-sharder/src/sharding/clustermanager.js:484:61)
    at ClusterManager.fetchInfo (eris-sharder/src/sharding/clustermanager.js:487:18)
```