### PR TITLE
Add stats per shard

### DIFF
--- a/src/sharding/cluster.js
+++ b/src/sharding/cluster.js
@@ -29,6 +29,7 @@ class Cluster {
         this.exclusiveGuilds = 0;
         this.largeGuilds = 0;
         this.voiceChannels = 0;
+        this.shardsStats = [];
         this.app = null;
         this.bot = null;
         this.test = false;
@@ -81,7 +82,8 @@ class Cluster {
                                 shards: this.shards,
                                 exclusiveGuilds: this.exclusiveGuilds,
                                 largeGuilds: this.largeGuilds,
-                                voice: this.voiceChannels
+                                voice: this.voiceChannels,
+                                shardsStats: this.shardsStats
                             }
                         });
                         break;
@@ -229,6 +231,15 @@ class Cluster {
             this.voiceChannels = bot.voiceConnections.size;
             this.largeGuilds = bot.guilds.filter(g => g.large).length;
             this.exclusiveGuilds = bot.guilds.filter(g => g.members.filter(m => m.bot).length === 1).length;
+            this.shardsStats = [];
+            this.bot.shards.forEach(shard => {
+                this.shardsStats.push({
+                    id: shard.id,
+                    ready: shard.ready,
+                    latency: shard.latency,
+                    status: shard.status
+                });
+            });
         }, 1000 * 5);
     }
 }

--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -250,7 +250,8 @@ class ClusterManager extends EventEmitter {
                             voice: message.stats.voice,
                             uptime: message.stats.uptime,
                             exclusiveGuilds: message.stats.exclusiveGuilds,
-                            largeGuilds: message.stats.largeGuilds
+                            largeGuilds: message.stats.largeGuilds,
+                            shardsStats: message.stats.shardsStats
                         });
 
                         this.stats.clustersCounted += 1;


### PR DESCRIPTION
Added a per shard stats on each cluster stats object. Useful for checking individual shard status and connection latency.

The stats object will look like
```
{
  "guilds":0,
  "users":0,
  [...]
  "clusters":[
    {
      "cluster":0,
      "shards":5,
      [...]
      "shardsStats":[
        {
          "id":0,
          "ready":true,
          "latency":31,
          "status":"ready"
        },
        {
          "id":1,
          "ready":true,
          "latency":33,
          "status":"ready"
        },
```
