### PR TITLE
Add a way to disable stat logging

### DIFF
--- a/src/sharding/clustermanager.js
+++ b/src/sharding/clustermanager.js
@@ -84,20 +84,22 @@ class ClusterManager extends EventEmitter {
     }
 
     startStats() {
-        setInterval(() => {
-            this.stats.stats.guilds = 0;
-            this.stats.stats.users = 0;
-            this.stats.stats.totalRam = 0;
-            this.stats.stats.clusters = [];
-            this.stats.stats.voice = 0;
-            this.stats.stats.exclusiveGuilds = 0;
-            this.stats.stats.largeGuilds = 0;
-            this.stats.clustersCounted = 0;
+        if (this.statsInterval != null) {
+            setInterval(() => {
+                this.stats.stats.guilds = 0;
+                this.stats.stats.users = 0;
+                this.stats.stats.totalRam = 0;
+                this.stats.stats.clusters = [];
+                this.stats.stats.voice = 0;
+                this.stats.stats.exclusiveGuilds = 0;
+                this.stats.stats.largeGuilds = 0;
+                this.stats.clustersCounted = 0;
 
-            let clusters = Object.entries(master.workers);
+                let clusters = Object.entries(master.workers);
 
-            this.executeStats(clusters, 0);
-        }, this.statsInterval);
+                this.executeStats(clusters, 0);
+            }, this.statsInterval);
+        }
     }
 
     /**


### PR DESCRIPTION
Setting the option `statsInterval` to `null` will disable the interval that sends statistic information for the cluster. This is useful for people who do not wish to report statistics, such as myself.